### PR TITLE
Output save file

### DIFF
--- a/connectdialog.cpp
+++ b/connectdialog.cpp
@@ -33,17 +33,17 @@ ConnectDialog::ConnectDialog(QWidget *parent) :
 
     // define a default configuration
     QHash<QString, QString> default_cfg;
-    default_cfg["device"] = default_device;
-    default_cfg["baud_rate"] = QString::number(QSerialPort::Baud115200);
-    default_cfg["data_bits"] = QString::number(QSerialPort::Data8);
-    default_cfg["stop_bits"] = QString("1");
-    default_cfg["parity"] = QString("None");
-    default_cfg["flow_control"] = QString("None");
+    default_cfg[QStringLiteral("device")] = default_device;
+    default_cfg[QStringLiteral("baud_rate")] = QString::number(QSerialPort::Baud115200);
+    default_cfg[QStringLiteral("data_bits")] = QString::number(QSerialPort::Data8);
+    default_cfg[QStringLiteral("stop_bits")] = QStringLiteral("1");
+    default_cfg[QStringLiteral("parity")] = QStringLiteral("None");
+    default_cfg[QStringLiteral("flow_control")] = QStringLiteral("None");
 
     // define the default values for output dump
-    default_cfg["dump_enabled"] = QString::number(0);
-    default_cfg["dump_file"] = QString("cutecom-ng.dump");
-    default_cfg["dump_format"] = QString("raw");
+    default_cfg[QStringLiteral("dump_enabled")] = QString::number(0);
+    default_cfg[QStringLiteral("dump_file")] = QStringLiteral("cutecom-ng.dump");
+    default_cfg[QStringLiteral("dump_format")] = QStringLiteral("raw");
 
     preselectPortConfig(default_cfg);
 }
@@ -101,18 +101,18 @@ void ConnectDialog::fillSettingsLists()
 
 void ConnectDialog::preselectPortConfig(const QHash<QString, QString>& settings)
 {
-    ui->deviceList->setCurrentText(settings["device"]);
-    ui->baudRateList->setCurrentText(settings["baud_rate"]);
-    ui->dataBitsList->setCurrentText(settings["data_bits"]);
-    ui->stopBitsList->setCurrentText(settings["stop_bits"]);
+    ui->deviceList->setCurrentText(settings[QStringLiteral("device")]);
+    ui->baudRateList->setCurrentText(settings[QStringLiteral("baud_rate")]);
+    ui->dataBitsList->setCurrentText(settings[QStringLiteral("data_bits")]);
+    ui->stopBitsList->setCurrentText(settings[QStringLiteral("stop_bits")]);
 
-    ui->parityList->setCurrentText(settings["parity"]);
-    ui->flowControlList->setCurrentText(settings["flow_control"]);
+    ui->parityList->setCurrentText(settings[QStringLiteral("parity")]);
+    ui->flowControlList->setCurrentText(settings[QStringLiteral("flow_control")]);
 
-    ui->dumpFile->setChecked(settings["dump_enabled"] == "1");
-    ui->dumpPath->setText(settings["dump_file"]);
-    ui->dumpRawFmt->setChecked(settings["dump_format"] == "raw");
-    ui->dumpTextFmt->setChecked(settings["dump_format"] == "ascii");
+    ui->dumpFile->setChecked(settings[QStringLiteral("dump_enabled")] == "1");
+    ui->dumpPath->setText(settings[QStringLiteral("dump_file")]);
+    ui->dumpRawFmt->setChecked(settings["dump_format"] == QString::number(Raw));
+    ui->dumpTextFmt->setChecked(settings["dump_format"] == QString::number(Ascii));
 }
 
 void ConnectDialog::accept()
@@ -130,7 +130,7 @@ void ConnectDialog::accept()
                 ui->flowControlList->currentIndex()).toString();
     cfg["dump_enabled"] = ui->dumpFile->isChecked() ? "1" : "0";
     cfg["dump_file"] = ui->dumpPath->text();
-    cfg["dump_format"] = ui->dumpRawFmt->isChecked() ? "raw" : "ascii";
+    cfg["dump_format"] = QString::number(ui->dumpRawFmt->isChecked() ? Raw : Ascii);
 
     hide();
 

--- a/connectdialog.cpp
+++ b/connectdialog.cpp
@@ -26,20 +26,26 @@ ConnectDialog::ConnectDialog(QWidget *parent) :
     // fill the combo box values
     fillSettingsLists();
 
-    // define the default values
-
     // for device take 1st device listed (if any)
     QString default_device;
     if (ui->deviceList->count() > 0)
         default_device = ui->deviceList->itemText(0);
-    defaultValues["device"] = default_device;
-    defaultValues["baud_rate"] = QString::number(QSerialPort::Baud115200);
-    defaultValues["data_bits"] = QString::number(QSerialPort::Data8);
-    defaultValues["stop_bits"] = QString("1");
-    defaultValues["parity"] = QString("None");
-    defaultValues["flow_control"] = QString("None");
 
-    preselectPortSettings(defaultValues);
+    // define a default configuration
+    QHash<QString, QString> default_cfg;
+    default_cfg["device"] = default_device;
+    default_cfg["baud_rate"] = QString::number(QSerialPort::Baud115200);
+    default_cfg["data_bits"] = QString::number(QSerialPort::Data8);
+    default_cfg["stop_bits"] = QString("1");
+    default_cfg["parity"] = QString("None");
+    default_cfg["flow_control"] = QString("None");
+
+    // define the default values for output dump
+    default_cfg["dump_enabled"] = QString::number(0);
+    default_cfg["dump_file"] = QString("./output.raw");
+    default_cfg["dump_format"] = QString("raw");
+
+    preselectPortSettings(default_cfg);
 }
 
 ConnectDialog::~ConnectDialog()
@@ -63,7 +69,7 @@ void ConnectDialog::fillSettingsLists()
     baud_rates <<
         QString::number(QSerialPort::Baud19200) << QString::number(QSerialPort::Baud38400);
     baud_rates <<
-        QString::number(QSerialPort::Baud57600) << QString::number(QSerialPort::Baud115200); 
+        QString::number(QSerialPort::Baud57600) << QString::number(QSerialPort::Baud115200);
     ui->baudRateList->addItems(baud_rates);
 
     // fill data bits combo box
@@ -102,6 +108,9 @@ void ConnectDialog::preselectPortSettings(const QHash<QString, QString>& setting
     ui->stopBitsList->setCurrentText(settings["stop_bits"]);
     ui->parityList->setCurrentText(settings["parity"]);
     ui->flowControlList->setCurrentText(settings["flow_control"]);
+    ui->dumpFile->setChecked(settings["dump_enabled"] == "1");
+    ui->dumpPath->setText(settings["dump_file"]);
+    ui->dumpRawFmt->setChecked(settings["dump_format"] == "raw");
 }
 
 void ConnectDialog::accept()
@@ -117,6 +126,9 @@ void ConnectDialog::accept()
                 ui->parityList->currentIndex()).toString();
     cfg["flow_control"] = ui->flowControlList->itemData(
                 ui->flowControlList->currentIndex()).toString();
+    cfg["dump_enabled"] = ui->dumpFile->isChecked() ? "1" : "0";
+    cfg["dump_file"] = ui->dumpPath->text();
+    cfg["dump_format"] = ui->dumpRawFmt->isChecked() ? "raw" : "ascii";
 
     close();
 

--- a/connectdialog.cpp
+++ b/connectdialog.cpp
@@ -42,7 +42,7 @@ ConnectDialog::ConnectDialog(QWidget *parent) :
 
     // define the default values for output dump
     default_cfg["dump_enabled"] = QString::number(0);
-    default_cfg["dump_file"] = QString("./output.raw");
+    default_cfg["dump_file"] = QString("cutecom-ng.dump");
     default_cfg["dump_format"] = QString("raw");
 
     preselectPortConfig(default_cfg);

--- a/connectdialog.cpp
+++ b/connectdialog.cpp
@@ -43,7 +43,7 @@ ConnectDialog::ConnectDialog(QWidget *parent) :
     // define the default values for output dump
     default_cfg[QStringLiteral("dump_enabled")] = QString::number(0);
     default_cfg[QStringLiteral("dump_file")] = QStringLiteral("cutecom-ng.dump");
-    default_cfg[QStringLiteral("dump_format")] = QStringLiteral("raw");
+    default_cfg[QStringLiteral("dump_format")] = QString::number(Raw);
 
     preselectPortConfig(default_cfg);
 }

--- a/connectdialog.cpp
+++ b/connectdialog.cpp
@@ -45,14 +45,13 @@ ConnectDialog::ConnectDialog(QWidget *parent) :
     default_cfg["dump_file"] = QString("./output.raw");
     default_cfg["dump_format"] = QString("raw");
 
-    preselectPortSettings(default_cfg);
+    preselectPortConfig(default_cfg);
 }
 
 ConnectDialog::~ConnectDialog()
 {
     delete ui;
 }
-
 
 void ConnectDialog::fillSettingsLists()
 {
@@ -100,17 +99,20 @@ void ConnectDialog::fillSettingsLists()
     ui->flowControlList->addItem("Software", QSerialPort::SoftwareControl);
 }
 
-void ConnectDialog::preselectPortSettings(const QHash<QString, QString>& settings)
+void ConnectDialog::preselectPortConfig(const QHash<QString, QString>& settings)
 {
     ui->deviceList->setCurrentText(settings["device"]);
     ui->baudRateList->setCurrentText(settings["baud_rate"]);
     ui->dataBitsList->setCurrentText(settings["data_bits"]);
     ui->stopBitsList->setCurrentText(settings["stop_bits"]);
+
     ui->parityList->setCurrentText(settings["parity"]);
     ui->flowControlList->setCurrentText(settings["flow_control"]);
+
     ui->dumpFile->setChecked(settings["dump_enabled"] == "1");
     ui->dumpPath->setText(settings["dump_file"]);
     ui->dumpRawFmt->setChecked(settings["dump_format"] == "raw");
+    ui->dumpTextFmt->setChecked(settings["dump_format"] == "ascii");
 }
 
 void ConnectDialog::accept()
@@ -130,7 +132,7 @@ void ConnectDialog::accept()
     cfg["dump_file"] = ui->dumpPath->text();
     cfg["dump_format"] = ui->dumpRawFmt->isChecked() ? "raw" : "ascii";
 
-    close();
+    hide();
 
     emit openDeviceClicked(cfg);
 }

--- a/connectdialog.h
+++ b/connectdialog.h
@@ -27,6 +27,15 @@ class ConnectDialog : public QDialog
     Q_OBJECT
 
 public:
+    /**
+     * \brief dump file formats
+     */
+    enum DumpFormat {
+        Raw   = 1,
+        Ascii = 2
+    };
+
+public:
     explicit ConnectDialog(QWidget *parent = 0);
     ~ConnectDialog();
 
@@ -59,7 +68,7 @@ signals:
      *  - "flow_control"
      *  - "dump_enabled" dump enabled/disabled
      *  - "dump_file" full path of dump file
-     *  - "dump_format" 'raw' or 'ascii'
+     *  - "dump_format" DumpFormat enum 'Raw' or 'Ascii'
      */
     void openDeviceClicked(const QHash<QString, QString>& config);
 };

--- a/connectdialog.h
+++ b/connectdialog.h
@@ -61,7 +61,6 @@ signals:
      *  - "dump_enabled" dump enabled/disabled
      *  - "dump_file" full path of dump file
      *  - "dump_format" 'raw' or 'ascii'
-     * All values are QStrings
      */
     void openDeviceClicked(const QHash<QString, QString>& config);
 };

--- a/connectdialog.h
+++ b/connectdialog.h
@@ -36,36 +36,32 @@ public:
 private:
     Ui::ConnectDialog *ui;
 
-
     /**
-     * \brief Represent the default serial port settings
-     *
-     * Has the following keys :
-     *  - "device"
-     *  - "baud_rate"
-     *  - "data_bits"
-     *  - "stop_bits"
-     *  - "parity"
-     *  - "flow_control"
-     * All values are QStrings
-     */
-    QHash<QString, QString> defaultValues;
-
-private:
-    /**
-     * fill connection settings combo boxes
+     * \brief fill connection settings combo boxes
      */
     void fillSettingsLists();
 
     /**
-     * preselect serial port connection settings
+     * \brief preselect serial port connection settings
      */
     void preselectPortSettings(const QHash<QString, QString>& settings);
 
 
 signals:
     /**
-     * signal emitted 'open device' button has been clicked
+     * \brief signal emitted 'open device' button has been clicked
+     *
+     * config parameter is a QHash with the following keys :
+     *  - "device"
+     *  - "baud_rate"
+     *  - "data_bits"
+     *  - "stop_bits"
+     *  - "parity"
+     *  - "flow_control"
+     *  - "dump_enabled" dump enabled/disabled
+     *  - "dump_file" full path of dump file
+     *  - "dump_format" 'raw' or 'ascii'
+     * All values are QStrings
      */
     void openDeviceClicked(const QHash<QString, QString>& config);
 };

--- a/connectdialog.h
+++ b/connectdialog.h
@@ -19,7 +19,6 @@ class ConnectDialog;
 }
 
 
-
 /**
  * \brief The ConnectDialog class
  */
@@ -42,9 +41,9 @@ private:
     void fillSettingsLists();
 
     /**
-     * \brief preselect serial port connection settings
+     * \brief preselect serial port connection configuration
      */
-    void preselectPortSettings(const QHash<QString, QString>& settings);
+    void preselectPortConfig(const QHash<QString, QString>& settings);
 
 
 signals:

--- a/connectdialog.ui
+++ b/connectdialog.ui
@@ -63,8 +63,8 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="QComboBox" name="dataBitsList"/>
+   <item row="1" column="3">
+    <widget class="QComboBox" name="stopBitsList"/>
    </item>
    <item row="1" column="2">
     <widget class="QLabel" name="label_4">
@@ -73,8 +73,8 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="3">
-    <widget class="QComboBox" name="stopBitsList"/>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="dataBitsList"/>
    </item>
    <item row="2" column="0">
     <widget class="QLabel" name="label_5">
@@ -86,6 +86,9 @@
    <item row="2" column="1">
     <widget class="QComboBox" name="parityList"/>
    </item>
+   <item row="2" column="3">
+    <widget class="QComboBox" name="flowControlList"/>
+   </item>
    <item row="2" column="2">
     <widget class="QLabel" name="label_6">
      <property name="styleSheet">
@@ -96,133 +99,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="3">
-    <widget class="QComboBox" name="flowControlList"/>
-   </item>
-   <item row="3" column="0" colspan="4">
-    <widget class="QGroupBox" name="dumpFile">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>80</width>
-       <height>120</height>
-      </size>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">QGroupBox {  border: 1px solid rgb(130, 64, 166);}</string>
-     </property>
-     <property name="title">
-      <string>Dump File</string>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-     <property name="text" stdset="0">
-      <string>Dump File</string>
-     </property>
-     <widget class="QWidget" name="">
-      <property name="geometry">
-       <rect>
-        <x>13</x>
-        <y>32</y>
-        <width>299</width>
-        <height>57</height>
-       </rect>
-      </property>
-      <layout class="QGridLayout" name="gridLayout_2">
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_7">
-         <property name="text">
-          <string>Path</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="2" colspan="3">
-        <widget class="QLineEdit" name="dumpPath">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_8">
-         <property name="text">
-          <string>Type</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="1" column="2" colspan="2">
-        <widget class="QRadioButton" name="dumpTextFmt">
-         <property name="text">
-          <string>Text</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="4">
-        <widget class="QRadioButton" name="dumpRawFmt">
-         <property name="text">
-          <string>Raw</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <spacer name="horizontalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Fixed</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="4">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>358</width>
-       <height>112</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="5" column="1" colspan="3">
+   <item row="4" column="1" colspan="3">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <property name="spacing">
       <number>5</number>
@@ -265,6 +142,58 @@
       </widget>
      </item>
     </layout>
+   </item>
+   <item row="3" column="0" colspan="4">
+    <widget class="QGroupBox" name="dumpFile">
+     <property name="title">
+      <string>Dump File</string>
+     </property>
+     <property name="flat">
+      <bool>false</bool>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>Path</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_8">
+        <property name="text">
+         <string>Type</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QRadioButton" name="radioButton">
+        <property name="text">
+         <string>text</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QRadioButton" name="radioButton_2">
+        <property name="text">
+         <string>raw</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1" colspan="2">
+       <widget class="QLineEdit" name="lineEdit"/>
+      </item>
+     </layout>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/connectdialog.ui
+++ b/connectdialog.ui
@@ -88,6 +88,9 @@
    </item>
    <item row="2" column="2">
     <widget class="QLabel" name="label_6">
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
      <property name="text">
       <string>Flow control</string>
      </property>
@@ -99,7 +102,7 @@
    <item row="3" column="0" colspan="4">
     <widget class="QGroupBox" name="dumpFile">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -110,6 +113,9 @@
        <height>120</height>
       </size>
      </property>
+     <property name="styleSheet">
+      <string notr="true">QGroupBox {  border: 1px solid rgb(130, 64, 166);}</string>
+     </property>
      <property name="title">
       <string>Dump File</string>
      </property>
@@ -119,78 +125,85 @@
      <property name="text" stdset="0">
       <string>Dump File</string>
      </property>
-     <widget class="QWidget" name="layoutWidget">
+     <widget class="QWidget" name="">
       <property name="geometry">
        <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>186</width>
-        <height>48</height>
+        <x>13</x>
+        <y>32</y>
+        <width>299</width>
+        <height>57</height>
        </rect>
       </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0">
-       <property name="sizeConstraint">
-        <enum>QLayout::SetMaximumSize</enum>
-       </property>
-       <property name="topMargin">
-        <number>20</number>
-       </property>
-       <item>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="0" column="0">
         <widget class="QLabel" name="label_7">
          <property name="text">
           <string>Path</string>
          </property>
         </widget>
        </item>
-       <item>
+       <item row="0" column="2" colspan="3">
         <widget class="QLineEdit" name="dumpPath">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
         </widget>
        </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="layoutWidget">
-      <property name="geometry">
-       <rect>
-        <x>22</x>
-        <y>61</y>
-        <width>182</width>
-        <height>77</height>
-       </rect>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_3">
-       <property name="spacing">
-        <number>0</number>
-       </property>
-       <item>
+       <item row="1" column="0">
         <widget class="QLabel" name="label_8">
          <property name="text">
           <string>Type</string>
          </property>
         </widget>
        </item>
-       <item>
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <item>
-          <widget class="QRadioButton" name="dumpRawFmt">
-           <property name="text">
-            <string>Raw</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QRadioButton" name="dumpTextFmt">
-           <property name="text">
-            <string>Text</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
+       <item row="1" column="1">
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="1" column="2" colspan="2">
+        <widget class="QRadioButton" name="dumpTextFmt">
+         <property name="text">
+          <string>Text</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="4">
+        <widget class="QRadioButton" name="dumpRawFmt">
+         <property name="text">
+          <string>Raw</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Fixed</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </widget>

--- a/connectdialog.ui
+++ b/connectdialog.ui
@@ -173,7 +173,7 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QRadioButton" name="radioButton">
+       <widget class="QRadioButton" name="dumpTextFmt">
         <property name="text">
          <string>text</string>
         </property>
@@ -183,14 +183,14 @@
        </widget>
       </item>
       <item row="1" column="2">
-       <widget class="QRadioButton" name="radioButton_2">
+       <widget class="QRadioButton" name="dumpRawFmt">
         <property name="text">
          <string>raw</string>
         </property>
        </widget>
       </item>
       <item row="0" column="1" colspan="2">
-       <widget class="QLineEdit" name="lineEdit"/>
+       <widget class="QLineEdit" name="dumpPath"/>
       </item>
      </layout>
     </widget>

--- a/connectdialog.ui
+++ b/connectdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>300</height>
+    <height>350</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -97,6 +97,106 @@
     <widget class="QComboBox" name="flowControlList"/>
    </item>
    <item row="3" column="0" colspan="4">
+    <widget class="QGroupBox" name="dumpFile">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>80</width>
+       <height>120</height>
+      </size>
+     </property>
+     <property name="title">
+      <string>Dump File</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="text" stdset="0">
+      <string>Dump File</string>
+     </property>
+     <widget class="QWidget" name="layoutWidget">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>186</width>
+        <height>48</height>
+       </rect>
+      </property>
+      <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetMaximumSize</enum>
+       </property>
+       <property name="topMargin">
+        <number>20</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="label_7">
+         <property name="text">
+          <string>Path</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="dumpPath">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="layoutWidget">
+      <property name="geometry">
+       <rect>
+        <x>22</x>
+        <y>61</y>
+        <width>182</width>
+        <height>77</height>
+       </rect>
+      </property>
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QLabel" name="label_8">
+         <property name="text">
+          <string>Type</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout">
+         <item>
+          <widget class="QRadioButton" name="dumpRawFmt">
+           <property name="text">
+            <string>Raw</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="dumpTextFmt">
+           <property name="text">
+            <string>Text</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="4">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -109,7 +209,7 @@
      </property>
     </spacer>
    </item>
-   <item row="4" column="1" colspan="3">
+   <item row="5" column="1" colspan="3">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <property name="spacing">
       <number>5</number>

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -24,11 +24,14 @@ MainWindow::MainWindow(QWidget *parent) :
     ui(new Ui::MainWindow)
 {
     ui->setupUi(this);
-    connect(ui->connectButton, &QAbstractButton::clicked, this, &MainWindow::openConnectionDialog);
 
     // create session and output managers
     output_mgr = new OutputManager(this);
     session_mgr = new SessionManager(this);
+    connect_dlg = new ConnectDialog(this);
+
+    // show connection dialog
+    connect(ui->connectButton, &QAbstractButton::clicked, connect_dlg, &ConnectDialog::show);
 
     // handle reception of new data from serial port
     connect(session_mgr, &SessionManager::dataReceived, this, &MainWindow::handleDataReceived);
@@ -44,20 +47,15 @@ MainWindow::MainWindow(QWidget *parent) :
 
     // clear output text
     connect(session_mgr, &SessionManager::sessionStarted, ui->textOutput, &QTextEdit::clear);
+
+    // call openSession when user accepts/closes connection dialog
+    connect(connect_dlg, &ConnectDialog::openDeviceClicked, session_mgr, &SessionManager::openSession);
 }
 
 
 MainWindow::~MainWindow()
 {
     delete ui;
-}
-
-void MainWindow::openConnectionDialog()
-{
-    ConnectDialog dialog(this);
-
-    connect(&dialog, &ConnectDialog::openDeviceClicked, session_mgr, &SessionManager::openSession);
-    dialog.exec();
 }
 
 void MainWindow::handleNewInput(QString entry)

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -30,8 +30,8 @@ MainWindow::MainWindow(QWidget *parent) :
     output_mgr = new OutputManager(this);
     session_mgr = new SessionManager(this);
 
-    // let output manager handle new data coming from serial port
-    connect(session_mgr, &SessionManager::dataReceived, output_mgr, &OutputManager::handleNewData);
+    // handle reception of new data from serial port
+    connect(session_mgr, &SessionManager::dataReceived, this, &MainWindow::handleDataReceived);
 
     // get data formatted for display and show it in output view
     connect(output_mgr, &OutputManager::dataConverted, this, &MainWindow::addDataToView);
@@ -86,4 +86,10 @@ void MainWindow::addDataToView(const QString & textdata)
     // push scroll to the bottom
     QScrollBar *vbar = ui->textOutput->verticalScrollBar();
     vbar->setValue(vbar->maximum());
+}
+
+
+void MainWindow::handleDataReceived(const QByteArray &data)
+{
+    (*output_mgr) << data;
 }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -38,6 +38,12 @@ MainWindow::MainWindow(QWidget *parent) :
 
     // get data formatted for display and show it in output view
     connect(ui->inputBox, &HistoryComboBox::lineEntered, this, &MainWindow::handleNewInput);
+
+    // clear output manager buffer at session start
+    connect(session_mgr, &SessionManager::sessionStarted, output_mgr, &OutputManager::clear);
+
+    // clear output text
+    connect(session_mgr, &SessionManager::sessionStarted, ui->textOutput, &QTextEdit::clear);
 }
 
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -21,6 +21,7 @@ class MainWindow;
 
 class SessionManager;
 class OutputManager;
+class ConnectDialog;
 
 /**
  * \brief main cutecom-ng window
@@ -33,6 +34,7 @@ private:
     Ui::MainWindow *ui;
     SessionManager *session_mgr;
     OutputManager *output_mgr;
+    ConnectDialog *connect_dlg;
 
 public:
     explicit MainWindow(QWidget *parent = 0);
@@ -44,11 +46,6 @@ private:
      * \brief handle return
      */
     void handleNewInput(QString entry);
-
-    /**
-     * \brief show the connection dialog
-     */
-    void openConnectionDialog();
 
     /**
      * \brief add data to the output view

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -41,19 +41,24 @@ public:
 private:
 
     /**
-     * /brief handle return
+     * \brief handle return
      */
     void handleNewInput(QString entry);
 
     /**
-     * /brief show the connection dialog
+     * \brief show the connection dialog
      */
     void openConnectionDialog();
 
     /**
-     * /brief add data to the output view
+     * \brief add data to the output view
      */
     void addDataToView(const QString & textdata);
+
+    /**
+     * \brief handle arrival of new data
+     */
+    void handleDataReceived(const QByteArray &data);
 };
 
 #endif // MAINWINDOW_H

--- a/outputmanager.cpp
+++ b/outputmanager.cpp
@@ -19,8 +19,19 @@ OutputManager::OutputManager(QObject *parent) : QObject(parent)
 void OutputManager::handleNewData(const QByteArray &data)
 {
     // append raw data to the session buffer
-    buffer.append(data);
+    _buffer.append(data);
 
     // notify that we have new data (in display format)
     emit dataConverted(QString::fromLocal8Bit(data));
+}
+
+const QByteArray& OutputManager::buffer()
+{
+    return _buffer;
+}
+
+
+void OutputManager::clear()
+{
+    _buffer.clear();
 }

--- a/outputmanager.cpp
+++ b/outputmanager.cpp
@@ -11,9 +11,6 @@
 
 #include "outputmanager.h"
 
-#include <algorithm>
-#include <iterator>
-
 OutputManager::OutputManager(QObject *parent) : QObject(parent)
 {
 
@@ -21,40 +18,11 @@ OutputManager::OutputManager(QObject *parent) : QObject(parent)
 
 void OutputManager::operator << (const QByteArray &data)
 {
-    // problem : if a buffer ending with "\r\n" happens to be cut between '\r' and '\n'
-    //           the 2 resulting QString will be interpreted as having 2 line jumps,
-    //           instead of 1, if displayed in a QTextEdit.
-    //           To avoid this, final '\r' are removed from the received buffer,
-    //           and prepended to the next one
-
-    // flag indicating that the previously received buffer ended with CR
-    static bool prev_ends_with_CR = false;
-
     // append raw data to the buffer, untouched
     _buffer.append(data);
 
-    QString to_send;
-    if (prev_ends_with_CR)
-    {
-        // CR was removed at the previous buffer, so now we prepend it
-        to_send.append('\r');
-        prev_ends_with_CR = false;
-    }
-
-    if (data.size() > 0)
-    {
-        QByteArray::const_iterator end_cit = data.cend();
-        if (data.endsWith('\r'))
-        {
-            // if buffer ends with CR, we don't copy it
-            end_cit--;
-            prev_ends_with_CR = true;
-        }
-        std::copy(data.begin(), end_cit, std::back_inserter(to_send));
-    }
-
     // notify that we have new data
-    emit dataConverted(to_send);
+    emit dataConverted(QString(data));
 }
 
 const QByteArray& OutputManager::buffer()

--- a/outputmanager.cpp
+++ b/outputmanager.cpp
@@ -11,6 +11,9 @@
 
 #include "outputmanager.h"
 
+#include <algorithm>
+#include <iterator>
+
 OutputManager::OutputManager(QObject *parent) : QObject(parent)
 {
 
@@ -18,11 +21,40 @@ OutputManager::OutputManager(QObject *parent) : QObject(parent)
 
 void OutputManager::operator << (const QByteArray &data)
 {
-    // append raw data to the session buffer
+    // problem : if a buffer ending with "\r\n" happens to be cut between '\r' and '\n'
+    //           the 2 resulting QString will be interpreted as having 2 line jumps,
+    //           instead of 1, if displayed in a QTextEdit.
+    //           To avoid this, final '\r' are removed from the received buffer,
+    //           and prepended to the next one
+
+    // flag indicating that the previously received buffer ended with CR
+    static bool prev_ends_with_CR = false;
+
+    // append raw data to the buffer, untouched
     _buffer.append(data);
 
-    // notify that we have new data (in display format)
-    emit dataConverted(QString::fromLocal8Bit(data));
+    QString to_send;
+    if (prev_ends_with_CR)
+    {
+        // CR was removed at the previous buffer, so now we prepend it
+        to_send.append('\r');
+        prev_ends_with_CR = false;
+    }
+
+    if (data.size() > 0)
+    {
+        QByteArray::const_iterator end_cit = data.cend();
+        if (data.endsWith('\r'))
+        {
+            // if buffer ends with CR, we don't copy it
+            end_cit--;
+            prev_ends_with_CR = true;
+        }
+        std::copy(data.begin(), end_cit, std::back_inserter(to_send));
+    }
+
+    // notify that we have new data
+    emit dataConverted(to_send);
 }
 
 const QByteArray& OutputManager::buffer()

--- a/outputmanager.cpp
+++ b/outputmanager.cpp
@@ -16,8 +16,6 @@ OutputManager::OutputManager(QObject *parent) : QObject(parent)
 
 }
 
-//void OutputManager::handleNewData(const QByteArray &data)
-
 void OutputManager::operator << (const QByteArray &data)
 {
     // append raw data to the session buffer

--- a/outputmanager.cpp
+++ b/outputmanager.cpp
@@ -16,7 +16,9 @@ OutputManager::OutputManager(QObject *parent) : QObject(parent)
 
 }
 
-void OutputManager::handleNewData(const QByteArray &data)
+//void OutputManager::handleNewData(const QByteArray &data)
+
+void OutputManager::operator << (const QByteArray &data)
 {
     // append raw data to the session buffer
     _buffer.append(data);

--- a/outputmanager.h
+++ b/outputmanager.h
@@ -18,7 +18,7 @@
 class QTextEdit;
 
 /**
- * \brief handle display and saving of serial port output
+ * \brief handle output data
  */
 class OutputManager : public QObject
 {
@@ -26,7 +26,7 @@ class OutputManager : public QObject
 
 private:
 
-    /// buffer all the data received (concatenated)
+    /// data received in current session (concatenated)
     QByteArray buffer;
 
 public:

--- a/outputmanager.h
+++ b/outputmanager.h
@@ -27,14 +27,24 @@ class OutputManager : public QObject
 private:
 
     /// data received in current session (concatenated)
-    QByteArray buffer;
+    QByteArray _buffer;
 
 public:
     explicit OutputManager(QObject *parent = 0);
 
     /**
-     * /brief handle new data
-     * append the data to the buffer
+     * \brief retrieve internal buffer
+     */
+    const QByteArray& buffer();
+
+    /**
+     * \brief clear internal buffer
+     */
+    void clear();
+
+    /**
+     * \brief handle new data
+     * append data to the buffer
      */
     void handleNewData(const QByteArray &data);
 

--- a/outputmanager.h
+++ b/outputmanager.h
@@ -48,6 +48,9 @@ public:
      */
     void handleNewData(const QByteArray &data);
 
+
+    void operator << (const QByteArray &data);
+
 signals:
 
     void dataConverted(const QString & data);

--- a/outputmanager.h
+++ b/outputmanager.h
@@ -44,11 +44,9 @@ public:
 
     /**
      * \brief handle new data
-     * append data to the buffer
+     * append new data to the internal buffer
+     * and emit dataConverted signal
      */
-    void handleNewData(const QByteArray &data);
-
-
     void operator << (const QByteArray &data);
 
 signals:

--- a/sessionmanager.cpp
+++ b/sessionmanager.cpp
@@ -70,7 +70,11 @@ void SessionManager::openSession(const QHash<QString, QString>& port_cfg)
     serial->setStopBits(stop_bits);
     serial->setFlowControl(flow_control);
 
-    if (serial->open(QIODevice::ReadWrite) == false)
+    if (serial->open(QIODevice::ReadWrite))
+    {
+        emit sessionStarted();
+    }
+    else
     {
         QMessageBox::critical(NULL, tr("Error"), serial->errorString());
     }

--- a/sessionmanager.cpp
+++ b/sessionmanager.cpp
@@ -91,10 +91,10 @@ void SessionManager::saveToFile(const QByteArray &data)
 {
     QFile dump(curr_cfg["dump_file"]);
 
-    // mode is OR'ed with 'Text' flag in "ascii" mode
+    // mode is OR'ed with 'Text' flag in "Ascii" mode
     QIODevice::OpenMode mode = QIODevice::Append;
 
-    if (curr_cfg["dump_file"] == "ascii")
+    if (curr_cfg["dump_file"] == QString::number(ConnectDialog::Ascii))
         mode |= QIODevice::Text;
 
     if (dump.open(mode))

--- a/sessionmanager.cpp
+++ b/sessionmanager.cpp
@@ -108,8 +108,8 @@ void SessionManager::readData()
     emit dataReceived(data);
 }
 
-
 void SessionManager::sendToSerial(const QByteArray &data)
 {
     serial->write(data);
 }
+

--- a/sessionmanager.cpp
+++ b/sessionmanager.cpp
@@ -87,25 +87,29 @@ bool SessionManager::isSessionOpen() const
     return serial->isOpen();
 }
 
+void SessionManager::saveToFile(const QByteArray &data)
+{
+    QFile dump(curr_cfg["dump_file"]);
+
+    // mode is OR'ed with 'Text' flag in "ascii" mode
+    QIODevice::OpenMode mode = QIODevice::Append;
+
+    if (curr_cfg["dump_file"] == "ascii")
+        mode |= QIODevice::Text;
+
+    if (dump.open(mode))
+        dump.write(data);
+}
+
 void SessionManager::readData()
 {
     QByteArray data(serial->readAll());
 
-    if (curr_cfg["dump_enabled"] == "1")
-    {
-        QFile dump(curr_cfg["dump_file"]);
-
-        QIODevice::OpenMode mode = QIODevice::Append;
-
-        // mode is OR'ed with 'Text' flag in "ascii" mode
-        if (curr_cfg["dump_file"] == "ascii")
-            mode |= QIODevice::Text;
-
-        if (dump.open(mode))
-            dump.write(data);
-    }
-
     emit dataReceived(data);
+
+    // append to dump file if configured
+    if (curr_cfg["dump_enabled"] == "1")
+        saveToFile(data);
 }
 
 void SessionManager::sendToSerial(const QByteArray &data)

--- a/sessionmanager.cpp
+++ b/sessionmanager.cpp
@@ -14,6 +14,7 @@
 
 #include <QMessageBox>
 #include <QSerialPort>
+#include <QFile>
 
 SessionManager::SessionManager(QObject *parent)
     : QObject(parent)
@@ -72,6 +73,7 @@ void SessionManager::openSession(const QHash<QString, QString>& port_cfg)
 
     if (serial->open(QIODevice::ReadWrite))
     {
+        curr_cfg = port_cfg;
         emit sessionStarted();
     }
     else
@@ -88,6 +90,20 @@ bool SessionManager::isSessionOpen() const
 void SessionManager::readData()
 {
     QByteArray data(serial->readAll());
+
+    if (curr_cfg["dump_enabled"] == "1")
+    {
+        QFile dump(curr_cfg["dump_file"]);
+
+        QIODevice::OpenMode mode = QIODevice::Append;
+
+        // mode is OR'ed with 'Text' flag in "ascii" mode
+        if (curr_cfg["dump_file"] == "ascii")
+            mode |= QIODevice::Text;
+
+        if (dump.open(mode))
+            dump.write(data);
+    }
 
     emit dataReceived(data);
 }

--- a/sessionmanager.h
+++ b/sessionmanager.h
@@ -31,7 +31,7 @@ private:
     /// serial port instance
     QSerialPort            *serial;
 
-    /// current session config
+    /// current session configuration
     QHash<QString, QString> curr_cfg;
 
 public:

--- a/sessionmanager.h
+++ b/sessionmanager.h
@@ -55,6 +55,11 @@ public:
 signals:
 
     /**
+     * \brief signal emitted at the beggining of a new session
+     */
+    void sessionStarted();
+
+    /**
      * \brief signal emitted when new data has been received from the serial port
      * \param data    byte array data
      */

--- a/sessionmanager.h
+++ b/sessionmanager.h
@@ -19,7 +19,6 @@
 class QSerialPort;
 class OutputManager;
 
-
 /**
  * \brief manage serial port session
  */
@@ -28,7 +27,12 @@ class SessionManager : public QObject
     Q_OBJECT
 
 private:
-    QSerialPort   *serial;
+
+    /// serial port instance
+    QSerialPort            *serial;
+
+    /// current session config
+    QHash<QString, QString> curr_cfg;
 
 public:
 

--- a/sessionmanager.h
+++ b/sessionmanager.h
@@ -75,6 +75,11 @@ private:
      * \brief read data from serial port
      */
     void readData();
+
+    /**
+     * \brief save given data to configured dump file
+     */
+    void saveToFile(const QByteArray &data);
 };
 
 #endif // SESSIONMANAGER_H


### PR DESCRIPTION
- I created a checkable `QGroupBox` to contain the widgets for the serial output dump file settings. (there is still la bit of work on the layout i think)
- as said before, output internal buffer and output on screen are both cleared at session start whereas the dump file is not modified.
- implemented `<< operator` on `OutputMgr`
- dump file save/write implementation, i chose to do it simply in the `SessionManager`, where and when we receive the data from the serial port. `OutputManager` has nothing to do with file saving, it's about presenting the data. In the dump file there is no data conversion (at the exception of the end of lines). Also doing it in `OutputManager` would mean passing around the dump fiile name and format
- to not let the user lose the settings entered previously in the `ConnectDialog`, i am now keeping a pointer on the dialog and show/hide it when needed, in this way the settings remain. That was IMO easier than passing the `QHash` around between `MainWindow`, `ConnectDialog` and `SessionManager`.
