### PR TITLE
Add description to device name combobox items

### DIFF
--- a/connectdialog.cpp
+++ b/connectdialog.cpp
@@ -56,8 +56,31 @@ ConnectDialog::~ConnectDialog()
 void ConnectDialog::fillSettingsLists()
 {
     // fill devices combo box
-    foreach(QSerialPortInfo info, QSerialPortInfo::availablePorts())
-        ui->deviceList->addItem(info.portName(), info.portName());
+    QList<QSerialPortInfo> ports(QSerialPortInfo::availablePorts());
+    for (int idx = 0; idx < ports.length(); ++idx)
+    {
+        const QSerialPortInfo& port_info = ports.at(idx);
+        ui->deviceList->addItem(port_info.portName());
+
+        // construct description tooltip
+        QString tooltip;
+
+        // add decription if not empty
+        if (!port_info.description().isEmpty())
+            tooltip.append(port_info.description());
+        if (!port_info.manufacturer().isEmpty())
+        {
+            // add ' / manufacturer' if not empty
+            if (!tooltip.isEmpty())
+                tooltip.push_back(QStringLiteral(" / "));
+            tooltip.append(port_info.description());
+        }
+        // assign portName
+        if (tooltip.isEmpty())
+            tooltip = port_info.portName();
+
+        ui->deviceList->setItemData(idx, tooltip, Qt::ToolTipRole);
+    }
 
     // fill baud rates combo box
     QStringList baud_rates;

--- a/connectdialog.cpp
+++ b/connectdialog.cpp
@@ -73,7 +73,7 @@ void ConnectDialog::fillSettingsLists()
             // add ' / manufacturer' if not empty
             if (!tooltip.isEmpty())
                 tooltip.push_back(QStringLiteral(" / "));
-            tooltip.append(port_info.description());
+            tooltip.append(port_info.manufacturer());
         }
         // assign portName
         if (tooltip.isEmpty())


### PR DESCRIPTION
In a tooltip, add the most meaningful description possible composed of:
- description / manufacturer
- or description (if manufacturer is empty)
- or manufacturer (if description is empty)
- device name (if both description and manufacturer are empty)

using the `QSerialPort::description` is not always enough, as shown here : 

example : 
#### arduino board
- device            :  "ttyACM0"
- description       :  "0043"
- manufacturer      :  "Arduino  www.arduino.cc "
- serialNumber      :  "85336303532351714120"
#### FTDI board
- device            :  "ttyUSB0"
- description       :  "ChiPi USB  -  Serial"
- manufacturer      :  "FTDI"
- serialNumber      :  "FTG6PM4N"
