### PR TITLE
Minor ui adjustments

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -51,12 +51,12 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(session_mgr, &SessionManager::sessionStarted, output_mgr, &OutputManager::clear);
 
     // clear output text
-    connect(session_mgr, &SessionManager::sessionStarted, ui->mainOutput, &QTextEdit::clear);
+    connect(session_mgr, &SessionManager::sessionStarted, ui->mainOutput, &QPlainTextEdit::clear);
 
     // call openSession when user accepts/closes connection dialog
     connect(connect_dlg, &ConnectDialog::openDeviceClicked, session_mgr, &SessionManager::openSession);
 
-    connect(ui->splitOutputBtn, &QPushButton::clicked, this, &MainWindow::toggleOutputSplitter);
+    connect(ui->splitOutputBtn, &QToolButton::clicked, this, &MainWindow::toggleOutputSplitter);
 
     // additional configuration for bottom output
     ui->bottomOutput->hide();

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -64,7 +64,7 @@
       <property name="childrenCollapsible">
        <bool>false</bool>
       </property>
-      <widget class="QTextEdit" name="mainOutput">
+      <widget class="QPlainTextEdit" name="mainOutput">
        <property name="font">
         <font>
          <family>Monospace</family>
@@ -75,7 +75,7 @@
         <bool>true</bool>
        </property>
       </widget>
-      <widget class="QTextEdit" name="bottomOutput">
+      <widget class="QPlainTextEdit" name="bottomOutput">
        <property name="font">
         <font>
          <family>Monospace</family>
@@ -99,6 +99,9 @@
     </item>
     <item>
      <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <property name="spacing">
+       <number>5</number>
+      </property>
       <item>
        <widget class="HistoryComboBox" name="inputBox">
         <property name="sizePolicy">
@@ -119,7 +122,7 @@
        </widget>
       </item>
       <item>
-       <widget class="QPushButton" name="splitOutputBtn">
+       <widget class="QToolButton" name="splitOutputBtn">
         <property name="text">
          <string/>
         </property>


### PR DESCRIPTION
- use a QPlainTextEdit instead of a QTextEdit as we want to display only
  text and the first is faster than the latter
- use a QToolButton instead of a QPushButton as it is displayed without
  extra spaces on Mac Os X.
