### PR TITLE
Disable input line when port is not connected

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -141,8 +141,9 @@ void MainWindow::handleSessionOpened()
     ui->connectButton->setDisabled(true);
     ui->disconnectButton->setEnabled(true);
 
-    // enable file transfer
+    // enable file transfer and input line
     ui->fileTransferButton->setEnabled(true);
+    ui->inputBox->setEnabled(true);
 }
 
 void MainWindow::handleSessionClosed()
@@ -150,8 +151,9 @@ void MainWindow::handleSessionClosed()
     ui->connectButton->setEnabled(true);
     ui->disconnectButton->setDisabled(true);
 
-    // disable file transfer
+    // disable file transfer and input line
     ui->fileTransferButton->setDisabled(true);
+    ui->inputBox->setDisabled(true);
 }
 
 void MainWindow::handleFileTransfer()

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -178,6 +178,9 @@
       </property>
       <item>
        <widget class="HistoryComboBox" name="inputBox">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>0</horstretch>


### PR DESCRIPTION
input line is now disabled by default and gets enabled when a session is opened
The same happens during the amount of time needed to free the resources after a file transfer :
- FileTransfer instance deletion
- transfer thread deletion
  During the freeing of resources, the input line, as well as the connect/disconnect buttons, have to be disabled to not interfere
