### PR TITLE
remove git hub api key secure envvar declaration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ sudo: required
 language: cpp
 
 before_install:
-# see here: https://github.com/numenta/nupic/blob/master/.travis.yml
 - "if [ ${TRAVIS_OS_NAME} = 'linux' ]; then . ./ci/travis/before_install-linux.sh; fi"
 - "if [ ${TRAVIS_OS_NAME} = 'osx' ]; then . ./ci/travis/before_install-osx.sh; fi"
 
@@ -20,15 +19,10 @@ before_deploy:
 
 deploy:
   provider: releases
+  # $GH_OAUTH_TOKEN envvar comes from travis-ci web gui
   api_key: $GH_OAUTH_TOKEN
   file_glob: true
   file: "${RELEASE_PKG_FILE}"
   skip_cleanup: true
   on:
     tags: true
-
-env:
-  global:
-    # with travis-cli: run 'travis encrypt GH_OAUTH_TOKEN=XXXX'
-    secure: "BLss8gzNmoD/JEGs/6RT0fN8A2bfZB8PBqq3fPbCDUI3Qgar4cpexIP2HxXPIKKdcpbiKUZg+fjowWhgfWbUE8mWF9aX9/PFgEixWEYNIoUH+lmmYv++/ZaTNhXAixIyQkPqo+nPkRbG49o8KCWShwUXlhjBOIj0x8MDFK6dS3e886pu0p77Pd/PcJCrIFRZ+nTIN0KhXrYIVFEDriOWv5SsG11PpjwNMoymN+UCWTDcif/moQnxuKHahZSmbGwEIDITPsUX9CUbLSS0clc7Id491g82jhU8pKP5jRnlUxYmXRP37l1Y9J/6OuFri27WdfgtdCg4CiwWA73fGQDk6w8IDs4oYO9Vd+m9nssPBEX6LwAJkNHq3WLDBH/YHDCxV2g2TLEYWzeRWwb2SSdyUW5Hmlg85s0cO4dpNoZxvtdi8iUrX5t7y5EC/AODdFxlf5gGpgPEcvDxyXAp1NBwfzL4rsR1m9KBXo65SSS7/NIapJEVShlLGlldqy1mkV5D8ctWP0/ANbqOK5kg774RFXuD1koeGnDWysc09gI6tgHhzN08+T8j38Qrd33H9AWdP4308feKteCTtvzpCbopAWUr8iHgXA7yqmOwd6pbWBVHG6N0yXyR5ajF85lKRrwzA1MbLLBB4IB3WHUYJDdmRa7gCCntjg4eioF4BNRIlyM="
-


### PR DESCRIPTION
GH_OAUTH_TOKEN has been set in develbot travis-ci account
so there is no need to have it here (also the one had been
uncorrectly defined and didn't allow travis to deploy to
GitHub Releases)
